### PR TITLE
Fix/32bitsize

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ the downloader as well as adding new torrents to the download queue.
 ## What's new?
 1. Fix PHP7.2 Compatible
 2. Use a longer timeout
+3. Hacky fix so that file size on 32bit PHP still works
 
 ## Installation
 
@@ -15,7 +16,7 @@ Installation is easy using [Composer](https://getcomposer.org):
 ```json
 {
     "require": {
-        "kslr/transmission-php": "master"
+        "ohnotnow/transmission-php": "master"
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Installation is easy using [Composer](https://getcomposer.org):
 ```json
 {
     "require": {
-        "ohnotnow/transmission-php": "master"
+        "kslr/transmission-php": "master"
     }
 }
 ```

--- a/lib/Transmission/Model/Torrent.php
+++ b/lib/Transmission/Model/Torrent.php
@@ -145,7 +145,7 @@ class Torrent extends AbstractModel
      */
     public function setSize($size)
     {
-        $this->size = (integer) $size;
+        $this->size = $size;
     }
 
     /**


### PR DESCRIPTION
Hi,

This is a small hacky fix for 32bit PHP. I spotted the problem when coding on a Raspberry PI.  It just removes the cast to integer on the size property as that limits the value to a 32bit value (ie, files >~ 2gb get the wrong value) - letting PHP treat it as a 'numeric string' allows things to work ok.